### PR TITLE
Quick fix

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -49,7 +49,10 @@ class Downloader:
 	def __init__(self, icon, url, localfile, opener, downloadWindow):
 		self.opener = opener # shared downloader
 		self.url = url
+		if (localfile.endswith(".ibooks")):
+			localfile = localfile[:-6]+".epub"
 		self.localfile = localfile
+		
 		#Reference to the download window's class
 		self._downloadWindow = downloadWindow
 		self._copyfile = downloadWindow.devicedir


### PR DESCRIPTION
This is one more quick fix for viewing some ebooks. We could add code to view .pages files' previews, but it seems pretty self-explanatory to open the quicklook folder, which has the preview in it. What do you think?
